### PR TITLE
Replace '-' in configuration keys by '_' for default variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,10 +22,10 @@ influxdb_databases:
 
 # User management
 influxdb_credentials_admin:
-  -  username: admin1
-     password: CHANGEME
-  -  username: admin2
-     password: CHANGEME
+  - username: admin1
+    password: CHANGEME
+  - username: admin2
+    password: CHANGEME
 
 influxdb_credentials_user:
   - username: user1
@@ -44,10 +44,10 @@ global:
   ## The data includes a random ID, os, arch, version, the number of series and other
   ## usage data. No data from user databases is ever transmitted.
   ## Change this option to true to disable reporting.
-  reporting-disabled: false
+  reporting_disabled: false
 
   ## Bind address to use for the RPC service for backup and restore.
-  bind-address: ":8088"
+  bind_address: ":8088"
 
 influxdb_config:
   ### [meta]
@@ -60,10 +60,10 @@ influxdb_config:
     dir: "/var/lib/influxdb/meta"
 
     ## Automatically create a default retention policy when creating a database.
-    # retention-autocreate: true
+    # retention_autocreate: true
 
     ## If log messages are printed for the meta service
-    # logging-enabled: true
+    # logging_enabled: true
 
 
   ### [data]
@@ -78,27 +78,27 @@ influxdb_config:
     dir: "/var/lib/influxdb/data"
 
     # The directory where the TSM storage engine stores WAL files.
-    wal-dir: "/var/lib/influxdb/wal"
+    wal_dir: "/var/lib/influxdb/wal"
 
     ## The amount of time that a write will wait before fsyncing.  A duration
     ## greater than 0 can be used to batch up multiple fsync calls.  This is useful for slower
     ## disks or when WAL write contention is seen.  A value of 0s fsyncs every write to the WAL.
     ## Values in the range of 0-100ms are recommended for non-SSD disks.
-    # wal-fsync-delay: "0s"
+    # wal_fsync_delay: "0s"
 
 
     ## The type of shard index to use for new shards.  The default is an in-memory index that is
     ## recreated at startup.  A value of "tsi1" will use a disk based index that supports higher
     ## cardinality datasets.
-    # index-version: "inmem"
+    # index_version: "inmem"
 
     ## Trace logging provides more verbose output around the tsm engine. Turning
     ## this on can provide more useful output for debugging tsm engine issues.
-    # trace-logging-enabled: false
+    # trace_logging_enabled: false
 
-    # Whether queries should be logged before execution. Very useful for troubleshooting, but will
-    # log any sensitive data contained within a query.
-    # query-log-enabled: true
+    ## Whether queries should be logged before execution. Very useful for troubleshooting, but will
+    ## log any sensitive data contained within a query.
+    # query_log_enabled: true
 
     ## Settings for the TSM engine
 
@@ -106,29 +106,29 @@ influxdb_config:
     ## reach before it starts rejecting writes.
     ## Valid size suffixes are k, m, or g (case insensitive, 1024 = 1k).
     ## Values without a size suffix are in bytes.
-    # cache-max-memory-size: "1g"
+    # cache_max_memory_size: "1g"
 
     ## CacheSnapshotMemorySize is the size at which the engine will
     ## snapshot the cache and write it to a TSM file, freeing up memory
     ## Valid size suffixes are k, m, or g (case insensitive, 1024 = 1k).
     ## Values without a size suffix are in bytes.
-    # cache-snapshot-memory-size: "25m"
+    # cache_snapshot_memory_size: "25m"
 
     ## CacheSnapshotWriteColdDuration is the length of time at
     ## which the engine will snapshot the cache and write it to
     ## a new TSM file if the shard hasn't received writes or deletes
-    # cache-snapshot-write-cold-duration: "10m"
+    # cache_snapshot_write_cold_duration: "10m"
 
     ## CompactFullWriteColdDuration is the duration at which the engine
     ## will compact all TSM files in a shard if it hasn't received a
     ## write or delete
-    # compact-full-write-cold-duration: "4h"
+    # compact_full_write_cold_duration: "4h"
 
     ## The maximum number of concurrent full and level compactions that can run at one time.  A
     ## value of 0 results in 50% of runtime.GOMAXPROCS(0) used at runtime.  Any number greater
     ## than 0 limits compactions to that value.  This setting does not apply
     ## to cache snapshotting.
-    # max-concurrent-compactions: 0
+    # max_concurrent_compactions: 0
 
     ## The threshold, in bytes, when an index write-ahead log file will compact
     ## into an index file. Lower sizes will cause log files to be compacted more
@@ -137,17 +137,17 @@ influxdb_config:
     ## and provide higher write throughput.
     ## Valid size suffixes are k, m, or g (case insensitive, 1024 = 1k).
     ## Values without a size suffix are in bytes.
-    # max-index-log-file-size: "1m"
+    # max_index_log_file_size: "1m"
 
     ## The maximum series allowed per database before writes are dropped.  This limit can prevent
     ## high cardinality issues at the database level.  This limit can be disabled by setting it to
     ## 0.
-    # max-series-per-database: 1000000
+    # max_series_per_database: 1000000
 
     ## The maximum number of tag values per tag that are allowed before writes are dropped.  This limit
     ## can prevent high cardinality tag values from being written to a measurement.  This limit can be
     ## disabled by setting it to 0.
-    # max-values-per-tag: 100000
+    # max_values_per_tag: 100000
 
 
   ### [http]
@@ -160,19 +160,19 @@ influxdb_config:
     enabled: true
 
     ## The bind address used by the HTTP service.
-    bind-address: ":8086"
+    bind_address: ":8086"
 
     ## Determines whether user authentication is enabled over HTTP/HTTPS.
-    auth-enabled: false
+    auth_enabled: false
 
     ## The default realm sent back when issuing a basic auth challenge.
     # realm: "InfluxDB"
 
     ## Determines whether HTTP request logging is enabled.
-    # log-enabled: true
+    # log_enabled: true
 
     ## Determines whether the HTTP write request logs should be suppressed when the log is enabled.
-    # suppress-write-log: false
+    # suppress_write_log: false
 
     ## When HTTP request logging is enabled, this option specifies the path where
     ## log entries should be written. If unspecified, the default is to write to stderr, which
@@ -180,42 +180,42 @@ influxdb_config:
     ##
     ## If influxd is unable to access the specified path, it will log an error and fall back to writing
     ## the request log to stderr.
-    # access-log-path: ""
+    # access_log_path: ""
 
     ## Determines whether detailed write logging is enabled.
-    # write-tracing: false
+    # write_tracing: false
 
     ## Determines whether the pprof endpoint is enabled.  This endpoint is used for
     ## troubleshooting and monitoring.
-    # pprof-enabled: true
+    # pprof_enabled: true
 
     ## Determines whether HTTPS is enabled.
-    https-enabled: false
+    https_enabled: false
 
     ## The SSL certificate to use when HTTPS is enabled.
-    # https-certificate: "/etc/ssl/influxdb.pem"
+    # https_certificate: "/etc/ssl/influxdb.pem"
 
     ## Use a separate private key location.
-    # https-private-key: ""
+    # https_private_key: ""
 
     ## The JWT auth shared secret to validate requests using JSON web tokens.
-    # shared-secret: ""
+    # shared_secret: ""
 
     ## The default chunk size for result sets that should be chunked.
-    # max-row-limit: 0
+    # max_row_limit: 0
 
     ## The maximum number of HTTP connections that may be open at once.  New connections that
     ## would exceed this limit are dropped.  Setting this value to 0 disables the limit.
-    # max-connection-limit: 0
+    # max_connection_limit: 0
 
     ## Enable http service over unix domain socket
-    # unix-socket-enabled: false
+    # unix_socket_enabled: false
 
     ## The path of the unix domain socket.
-    # bind-socket: "/var/run/influxdb.sock"
+    # bind_socket: "/var/run/influxdb.sock"
 
     ## The maximum size of a client request body, in bytes. Setting this value to 0 disables the limit.
-    # max-body-size: 25000000
+    # max_body_size: 25000000
 
 
   ### [coordinator]
@@ -224,33 +224,33 @@ influxdb_config:
   ###
   coordinator: {}
     ## The default time a write request will wait until a "timeout" error is returned to the caller.
-    # write-timeout: "10s"
+    # write_timeout: "10s"
 
     ## The maximum number of concurrent queries allowed to be executing at one time.  If a query is
     ## executed and exceeds this limit, an error is returned to the caller.  This limit can be disabled
     ## by setting it to 0.
-    # max-concurrent-queries: 0
+    # max_concurrent_queries: 0
 
     ## The maximum time a query will is allowed to execute before being killed by the system.  This limit
     ## can help prevent run away queries.  Setting the value to 0 disables the limit.
-    # query-timeout: "0s"
+    # query_timeout: "0s"
 
     ## The time threshold when a query will be logged as a slow query.  This limit can be set to help
     ## discover slow or resource intensive queries.  Setting the value to 0 disables the slow query logging.
-    # log-queries-after: "0s"
+    # log_queries_after: "0s"
 
     ## The maximum number of points a SELECT can process.  A value of 0 will make
     ## the maximum point count unlimited.  This will only be checked every second so queries will not
     ## be aborted immediately when hitting the limit.
-    # max-select-point: 0
+    # max_select_point: 0
 
     ## The maximum number of series a SELECT can run.  A value of 0 will make the maximum series
     ## count unlimited.
-    # max-select-series: 0
+    # max_select_series: 0
 
     ## The maxium number of group by time bucket a SELECT can create.  A value of zero will max the maximum
     ## number of buckets unlimited.
-    # max-select-buckets: 0
+    # max_select_buckets: 0
   
 
   ### [retention]
@@ -262,7 +262,7 @@ influxdb_config:
     # enabled: true
 
     ## The interval of time when retention policy enforcement checks run.
-    # check-interval: "30m"
+    # check_interval: "30m"
 
 
   ### [shard-precreation]
@@ -271,16 +271,16 @@ influxdb_config:
   ### Only shards that, after creation, will have both a start- and end-time in the
   ### future, will ever be created. Shards are never precreated that would be wholly
   ### or partially in the past.
-  shard_precreation: {}
+  shard-precreation: {}
     ## Determines whether shard pre-creation service is enabled.
     # enabled: true
 
     ## The interval of time when the check to pre-create new shards runs.
-    # check-interval: "10m"
+    # check_interval: "10m"
 
     ## The default period ahead of the endtime of a shard group that its successor
     ## group is created.
-    # advance-period: "30m"
+    # advance_period: "30m"
 
 
   ### Controls the system self-monitoring, statistics and diagnostics.
@@ -292,13 +292,13 @@ influxdb_config:
   ### this retention policy is configured as the default for the database.
   monitor: {}
     ## Whether to record statistics internally.
-    # store-enabled: true
+    # store_enabled: true
 
     ## The destination database for recorded statistics
-    # store-database: "_internal"
+    # store_database: "_internal"
 
     ## The interval at which to record statistics
-    # store-interval: "10s"
+    # store_interval: "10s"
 
 
   ### [ifql]
@@ -310,10 +310,10 @@ influxdb_config:
     # enabled: true
 
     ## Determines whether additional logging is enabled.
-    # log-enabled: true
+    # log_enabled: true
 
     ## The bind address used by the ifql RPC service.
-    # bind-address: ":8082"
+    # bind_address: ":8082"
 
 
   ### [logging]
@@ -335,7 +335,7 @@ influxdb_config:
 
     # Suppresses the logo output that is printed when the program is started.
     ## The logo is always suppressed if STDOUT is not a TTY.
-    # suppress-logo: false
+    # suppress_logo: false
     
 
   ### [subscriber]
@@ -348,20 +348,20 @@ influxdb_config:
     # enabled: true
 
     ## The default timeout for HTTP writes to subscribers.
-    # http-timeout: "30s"
+    # http_timeout: "30s"
 
-    # Allows insecure HTTPS connections to subscribers.  This is useful when testing with self-
+    ## Allows insecure HTTPS connections to subscribers.  This is useful when testing with self-
     ## signed certificates.
-    # insecure-skip-verify: false
+    # insecure_skip_verify: false
 
     ## The path to the PEM encoded CA certs file. If the empty string, the default system certs will be used
-    # ca-certs: ""
+    # ca_certs: ""
 
     ## The number of writer goroutines processing the write channel.
-    # write-concurrency: 40
+    # write_concurrency: 40
 
     ## The number of in-flight writes buffered in the write channel.
-    # write-buffer-size: 1000
+    # write_buffer_size: 1000
 
   
   ### [continuous_queries]
@@ -373,13 +373,13 @@ influxdb_config:
     enabled: true
 
     ## Controls whether queries are logged when executed by the CQ service.
-    log-enabled: true
+    log_enabled: true
 
     ## Controls whether queries are logged to the self-monitoring data store.
-    # query-stats-enabled: false
+    # query_stats_enabled: false
 
     ## interval for how often continuous queries will be checked if they need to run
-    # run-interval: "1s"
+    # run_interval: "1s"
     
 
   listeners:
@@ -387,26 +387,26 @@ influxdb_config:
       ## Determines whether the graphite endpoint is enabled.
       # enabled: false
       # database: "graphite"
-      # retention-policy: ""
-      # bind-address: ":2003"
+      # retention_policy: ""
+      # bind_address: ":2003"
       # protocol: "tcp"
-      # consistency-level: "one"
+      # consistency_level: "one"
 
       ## These next lines control how batching works. You should have this enabled
       ## otherwise you could get dropped metrics or poor performance. Batching
       ## will buffer points in memory if you have many coming in.
 
       ## Flush if this many points get buffered
-      # batch-size: 5000
+      # batch_size: 5000
 
       ## number of batches that may be pending in memory
-      # batch-pending: 10
+      # batch_pending: 10
 
       ## Flush at least this often even if we haven't hit buffer limit
-      # batch-timeout: "1s"
+      # batch_timeout: "1s"
 
       ## UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
-      # udp-read-buffer: 0
+      # udp_read_buffer: 0
 
       ## This string joins multiple matching 'measurement' values providing more control over the final measurement name.
       # separator: "."
@@ -426,84 +426,84 @@ influxdb_config:
       # ]
 
 
-    co#llectd: {}
+    collectd: {}
       ## enabled: false
       ## bind-address: ":25826"
       ## database: "collectd"
-      # retention-policy: ""
+      # retention_policy: ""
       
       ## The collectd service supports either scanning a directory for multiple types
       ## db files, or specifying a single db file.
       # typesdb: "/usr/local/share/collectd"
-      # security-level: "none"
-      # auth-file: "/etc/collectd/auth_file"
+      # security_level: "none"
+      # auth_file: "/etc/collectd/auth_file"
 
       ## These next lines control how batching works. You should have this enabled
       ## otherwise you could get dropped metrics or poor performance. Batching
       ## will buffer points in memory if you have many coming in.
 
       ## Flush if this many points get buffered
-      # batch-size: 5000
+      # batch_size: 5000
 
       ## Number of batches that may be pending in memory
-      # batch-pending: 10
+      # batch_pending: 10
 
       ## Flush at least this often even if we haven't hit buffer limit
-      # batch-timeout: "10s"
+      # batch_timeout: "10s"
 
       ## UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
-      # read-buffer: 0
+      # read_buffer: 0
 
       ## Multi-value plugins can be handled two ways.
       ## "split" will parse and store the multi-value plugin data into separate measurements
       ## "join" will parse and store the multi-value plugin as a single multi-value measurement.
       ## "split" is the default behavior for backward compatability with previous versions of influxdb.
-      # parse-multivalue-plugin: "split"
+      # parse_multivalue_plugin: "split"
 
     opentsdb: {}
       # enabled: false
-      # bind-address: ":4242"
+      # bind_address: ":4242"
       # database: "opentsdb"
-      # retention-policy: ""
-      # consistency-level: "one"
-      # tls-enabled: false
+      # retention_policy: ""
+      # consistency_level: "one"
+      # tls_enabled: false
       # certificate= "/etc/ssl/influxdb.pem"
 
       ## Log an error for every malformed point.
-      # log-point-errors: true
+      # log_point_errors: true
 
       ## These next lines control how batching works. You should have this enabled
       ## otherwise you could get dropped metrics or poor performance. Only points
       # metrics received over the telnet protocol undergo batching.
 
       ## Flush if this many points get buffered
-      # batch-size: 1000
+      # batch_size: 1000
 
       ## Number of batches that may be pending in memory
-      # batch-pending: 5
+      # batch_pending: 5
 
       ## Flush at least this often even if we haven't hit buffer limit
-      # batch-timeout: "1s"
+      # batch_timeout: "1s"
     
     
     udp: {}
       # enabled: false
-      # bind-address: ":8089"
+      # bind_address: ":8089"
       # database: "udp"
-      # retention-policy: ""
+      # retention_policy: ""
 
       ## These next lines control how batching works. You should have this enabled
       ## otherwise you could get dropped metrics or poor performance. Batching
       # will buffer points in memory if you have many coming in.
 
       ## Flush if this many points get buffered
-      # batch-size: 5000
+      # batch_size: 5000
 
       ## Number of batches that may be pending in memory
-      # batch-pending: 10
+      # batch_pending: 10
 
       ## Will flush at least this often even if we haven't hit buffer limit
-      # batch-timeout: "1s"
+      # batch_timeout: "1s"
 
       ## UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
-      # read-buffer: 0
+      # read_buffer: 0


### PR DESCRIPTION
- Replace '-' in configuration keys by '\_' for default variable since the template file can convert '_' to '-'
- On line 274, correct "shard_precreation" to "shard-precreation" ([ref](https://docs.influxdata.com/influxdb/v1.7/administration/config/#shard-precreation-settings))
- Fix co#llectd typo on line 429
- Fix some comments and indentions